### PR TITLE
Fix 게임 시작 이벤트 진행 로직

### DIFF
--- a/assets/game.json
+++ b/assets/game.json
@@ -1,0 +1,5 @@
+{
+  "name": "game",
+  "version": "1.0.0",
+  "data": { "userGold": 0, "baseHp": 200, "numOfinitialTowers": 3, "score": 0 }
+}

--- a/public/assets/game.json
+++ b/public/assets/game.json
@@ -1,0 +1,5 @@
+{
+  "name": "game",
+  "version": "1.0.0",
+  "data": { "userGold": 0, "baseHp": 200, "numOfinitialTowers": 3, "score": 0 }
+}

--- a/public/src/game.js
+++ b/public/src/game.js
@@ -2,6 +2,7 @@ import { Base } from './base.js';
 import { Monster } from './monster.js';
 import { Tower } from './tower.js';
 import towerData from '../assets/tower.json' with { type: 'json' };
+import game from '../assets/game.json' with { type: 'json' };
 import { CLIENT_VERSION } from './Constants.js';
 
 /* 
@@ -15,18 +16,18 @@ const ctx = canvas.getContext('2d');
 const NUM_OF_TOWERS = 5; // 타워 이미지 개수
 const NUM_OF_MONSTERS = 6; // 몬스터 이미지 개수
 
-let userGold = 0; // 유저 골드
+let userGold = game.data.userGold; // 유저 골드
 let base; // 기지 객체
-let baseHp = 200; // 기지 체력
+let baseHp = game.data.baseHp; // 기지 체력
 
 let towerCost = towerData.data[0].cost; // 타워 구입 비용
-let numOfInitialTowers = 0; // 초기 타워 개수
+let numOfInitialTowers = game.data.numOfinitialTowers; // 초기 타워 개수
 let monsterLevel = 1; // 몬스터 레벨
 let monsterSpawnInterval = 2000; // 몬스터 생성 주기 (ms)
 const monsters = [];
 const towers = [];
 
-let score = 0; // 게임 점수
+let score = game.data.score; // 게임 점수
 let highScore = 0; // 기존 최고 점수
 let isInitGame = false;
 
@@ -252,8 +253,7 @@ function initGame() {
 
   setInterval(spawnMonster, monsterSpawnInterval); // 설정된 몬스터 생성 주기마다 몬스터 생성
 
-  sendEvent(2, { timeStamp: Date.now() });
-  gameLoop(); // 게임 루프 최초 실행
+  sendEvent(2, { timeStamp: Date.now(), userGold, baseHp, numOfInitialTowers, score });
   isInitGame = true;
 }
 
@@ -290,6 +290,11 @@ Promise.all([
   */
   let userId = null;
   serverSocket.on('gameStart', (data) => {
+    if (data.status === 'success') {
+      gameLoop(); // 게임 루프 최초 실행
+    } else {
+      alert('게임 초기 정보 검증에 실패했습니다.');
+    }
     console.log(data);
   });
 

--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import { createServer } from 'http';
 import initSocket from './init/socket.js';
+import { loadGameAssets } from './init/assets.js';
 import config from './utils/configs.js';
 
 const app = express();
@@ -22,4 +23,10 @@ app.get('/', (req, res) => {
 
 server.listen(PORT, async () => {
   console.log(`Server is running on port ${PORT}`);
+  try {
+    await loadGameAssets();
+    console.log('게임 에셋 로드 성공');
+  } catch (error) {
+    console.error('게임 에셋 로드 실패');
+  }
 });

--- a/src/handlers/game.handler.js
+++ b/src/handlers/game.handler.js
@@ -1,13 +1,28 @@
-export const gameStart = (uuid, payload, socket) => {
-  // socket emit test
-  const { timeStamp } = payload;
+import { getGameAssets } from '../init/assets.js';
 
-  if (false) {
-    socket.emit('gameStart', { status: 'fail', message: '게임 시작 실패' });
-    return;
+export const gameStart = (uuid, payload, socket) => {
+  const { timeStamp, userGold, baseHp, numOfInitialTowers, score } = payload;
+  const { game } = getGameAssets();
+
+  const userGoldAsset = game.data.userGold;
+  const baseHpAsset = game.data.baseHp;
+  const numOfInitialTowersAsset = game.data.numOfinitialTowers;
+  const scoreAsset = game.data.score;
+
+  let verification = false;
+  if (
+    userGold === userGoldAsset &&
+    baseHp === baseHpAsset &&
+    numOfInitialTowers === numOfInitialTowersAsset &&
+    score === scoreAsset
+  ) {
+    verification = true;
   }
 
-  console.log(timeStamp);
+  if (!verification) {
+    socket.emit('gameStart', { status: 'fail', message: '게임 초기 정보 검증 실패' });
+    return;
+  }
 
   socket.emit('gameStart', { status: 'success', message: '게임 시작!' });
 };

--- a/src/init/assets.js
+++ b/src/init/assets.js
@@ -1,0 +1,47 @@
+// gameAssets.js
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// import.meta.url은 현재 모듈의 URL을 나타내는 문자열
+// fileURLToPath는 URL 문자열을 파일 시스템의 경로로 변환
+
+// 현재 파일의 절대 경로. 이 경로는 파일의 이름을 포함한 전체 경로
+const __filename = fileURLToPath(import.meta.url);
+
+// path.dirname() 함수는 파일 경로에서 디렉토리 경로만 추출 (파일 이름을 제외한 디렉토리의 전체 경로)
+const __dirname = path.dirname(__filename);
+const basePath = path.join(__dirname, '../../assets');
+
+let gameAssets = {}; // 전역함수로 선언
+
+const readFileAsync = (filename) => {
+  return new Promise((resolve, reject) => {
+    fs.readFile(path.join(basePath, filename), 'utf8', (err, data) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve(JSON.parse(data));
+    });
+  });
+};
+
+export const loadGameAssets = async () => {
+  try {
+    const [game, monster, stage, tower] = await Promise.all([
+      readFileAsync('game.json'),
+      readFileAsync('monster.json'),
+      readFileAsync('stage.json'),
+      readFileAsync('tower.json'),
+    ]);
+    gameAssets = { game, monster, stage, tower };
+    return gameAssets;
+  } catch (error) {
+    throw new Error('Failed to load game assets: ' + error.message);
+  }
+};
+
+export const getGameAssets = () => {
+  return gameAssets;
+};


### PR DESCRIPTION
### Fix 게임 시작 이벤트 진행 로직

- 게임 시작 이벤트 `(SendEvent(2, {})`를 `socket.on(’gameStart’, (data))` 안에 넣어서 처음 데이터 값을 game.json 파일로 가져오고, 서버에서 검증 진행
    - game.json 파일 작성
    - 게임 데이터가 서버와 일치하지 않으면 검증 실패
        - 게임이 시작되지 않게 설정

### 참고사항

- 서버 게임 에셋을 로드하기 위한 `asset.js` 생성하여 `gameAssets` 정의

### 게임 초기 정보 검증 실패 Alert 이미지

![검증 alert](https://github.com/eliotjang/tower-defense-game-project/assets/37320831/256199fa-a1ef-4756-8211-19177f926e57)


### 게임 초기 정보 검증 실패 클라이언트 콘솔창 이미지

![검증 실패 클라](https://github.com/eliotjang/tower-defense-game-project/assets/37320831/a4a4bf38-9df5-4776-891b-082bfa5bf6a1)

