### PR TITLE
Update 최초 타워 추가 이벤트

### DIFF
--- a/public/src/game.js
+++ b/public/src/game.js
@@ -152,17 +152,13 @@ function getRandomPositionNearPath(maxDistance) {
 }
 
 function placeInitialTowers() {
-  /* 
-    타워를 초기에 배치하는 함수입니다.
-    무언가 빠진 코드가 있는 것 같지 않나요? 
-  */
   for (let i = 0; i < numOfInitialTowers; i++) {
     const { x, y } = getRandomPositionNearPath(200);
     const tower = new Tower(x, y);
     towers.push(tower);
     tower.draw(ctx, towerImages[tower.getLevel()]);
+    sendEvent(30, { towerData: { x, y } });
   }
-  // sendEvent()
 }
 
 function placeNewTower() {
@@ -242,6 +238,7 @@ function initGame() {
   if (isInitGame) {
     return;
   }
+  sendEvent(2, { timeStamp: Date.now(), userGold, baseHp, numOfInitialTowers, score });
 
   monsterPath = generateRandomMonsterPath(); // 몬스터 경로 생성
   initMap(); // 맵 초기화 (배경, 몬스터 경로 그리기)
@@ -253,7 +250,6 @@ function initGame() {
 
   setInterval(spawnMonster, monsterSpawnInterval); // 설정된 몬스터 생성 주기마다 몬스터 생성
 
-  sendEvent(2, { timeStamp: Date.now(), userGold, baseHp, numOfInitialTowers, score });
   isInitGame = true;
 }
 
@@ -299,38 +295,74 @@ Promise.all([
   });
 
   serverSocket.on('gameEnd', (data) => {
+    if (data.status === 'success') {
+    } else {
+      alert('실패 메시지 입력');
+    }
     console.log(data);
   });
 
   serverSocket.on('monsterKill', (data) => {
+    if (data.status === 'success') {
+    } else {
+      alert('실패 메시지 입력');
+    }
     console.log(data);
   });
 
   serverSocket.on('monsterPass', (data) => {
+    if (data.status === 'success') {
+    } else {
+      alert('실패 메시지 입력');
+    }
     console.log(data);
   });
 
   serverSocket.on('goblinSpawn', (data) => {
+    if (data.status === 'success') {
+    } else {
+      alert('실패 메시지 입력');
+    }
     console.log(data);
   });
 
   serverSocket.on('moveStage', (data) => {
+    if (data.status === 'success') {
+    } else {
+      alert('실패 메시지 입력');
+    }
     console.log(data);
   });
 
   serverSocket.on('towerInitial', (data) => {
+    if (data.status === 'success') {
+    } else {
+      alert('최초 타워 추가 검증 실패');
+    }
     console.log(data);
   });
 
   serverSocket.on('towerPurchase', (data) => {
+    if (data.status === 'success') {
+    } else {
+      alert('실패 메시지 입력');
+    }
     console.log(data);
   });
 
   serverSocket.on('towerRefund', (data) => {
+    if (data.status === 'success') {
+    } else {
+      alert('실패 메시지 입력');
+    }
     console.log(data);
   });
 
   serverSocket.on('towerUpgrade', (data) => {
+    if (data.status === 'success') {
+    } else {
+      alert('실패 메시지 입력');
+    }
     console.log(data);
   });
 

--- a/src/handlers/tower.handler.js
+++ b/src/handlers/tower.handler.js
@@ -1,7 +1,11 @@
 export const towerInitialHandler = (userId, payload, socket) => {
-  const { numOfInitialTowers } = payload;
+  const { towerData } = payload;
 
-  if (false) {
+  console.log(towerData);
+
+  // 추후 Redis 연동하여 towerData 값 저장
+
+  if (!towerData) {
     socket.emit('towerInitial', { status: 'fail', message: '최초 타워 추가 검증 실패' });
     return;
   }


### PR DESCRIPTION
### Update 최초 타워 추가 이벤트

- 최초 타워는 numOfInitialTowers 값 만큼 공짜로 추가
-  game.js의 placeInitialTowers 함수를 참고
- 이벤트에 { x, y } 좌표를 전달
  - 서버에서는 유저 별로 최소한 어떤 좌표들에 타워가 있는지 체크하기 위함

### 참고사항

- Redis 연동 시 towerData 값 저장

### 최초 타워 추가 성공 서버 콘솔창 이미지 

![최초 타워 추가 검증 성공 서버](https://github.com/eliotjang/tower-defense-game-project/assets/37320831/9b7d47dc-1ba8-4627-8f2f-915e74ae02d6)


### 최초 타워 추가 성공 클라이언트 콘솔창 이미지 

![최초 타워 추가 검증 성공 클라](https://github.com/eliotjang/tower-defense-game-project/assets/37320831/a005a309-56ba-4089-88ce-67e4341fad7c)


### 최초 타워 추가 실패 클라이언트 Alert창 이미지

![최초 타워 추가 검증 실패](https://github.com/eliotjang/tower-defense-game-project/assets/37320831/e2f09f37-7013-4ade-8c23-7ec4b3b401ca)


### 최초 타워 추가 실패 클라이언트 콘솔창 이미지 

![최초 타워 추가 검증 실패 클라](https://github.com/eliotjang/tower-defense-game-project/assets/37320831/a075bdcb-63f2-4114-93c3-0fae5db67d49)

