### PR TITLE
Update 최초 타워 추가 이벤트 Redis 연동

### DIFF
--- a/src/handlers/game.handler.js
+++ b/src/handlers/game.handler.js
@@ -15,7 +15,7 @@ export const gameStart = async (uuid, payload, socket) => {
   await gameRedis.createGameData(uuid, userGold, stageId, score, numOfInitialTowers, baseHp);
   const data = await gameRedis.getGameData(uuid);
 
-  console.log('Redis 데이터', data);
+  //console.log('Redis 데이터', data);
 
   socket.emit('gameStart', {
     status: 'success',

--- a/src/handlers/monster.handler.js
+++ b/src/handlers/monster.handler.js
@@ -1,4 +1,4 @@
-export const monsterKillHandler = (userId, payload, socket) => {
+export const monsterKillHandler = (uuid, payload, socket) => {
   const { score: currentScore } = payload;
 
   if (false) {
@@ -9,7 +9,7 @@ export const monsterKillHandler = (userId, payload, socket) => {
   socket.emit('monsterKill', { status: 'success', message: '몬스터 처치 성공', score });
 };
 
-export const monsterPassHandler = (userId, payload, socket) => {
+export const monsterPassHandler = (uuid, payload, socket) => {
   const { monsterId } = payload;
 
   if (false) {
@@ -20,7 +20,7 @@ export const monsterPassHandler = (userId, payload, socket) => {
   socket.emit('monsterPass', { status: 'success', message: '몬스터 통과 성공' });
 };
 
-export const goblinSpawnHandler = (userId, payload, socket) => {
+export const goblinSpawnHandler = (uuid, payload, socket) => {
   const { goblinId, spawnTime } = payload;
 
   if (false) {

--- a/src/handlers/tower.handler.js
+++ b/src/handlers/tower.handler.js
@@ -1,9 +1,14 @@
-export const towerInitialHandler = (userId, payload, socket) => {
+import { gameRedis } from '../utils/redis.utils.js';
+
+export const towerInitialHandler = async (uuid, payload, socket) => {
   const { towerData } = payload;
 
-  console.log(towerData);
+  console.log('1', towerData);
 
-  // 추후 Redis 연동하여 towerData 값 저장
+  await gameRedis.patchGameDataTower(uuid, towerData);
+
+  const user = await gameRedis.getGameData(uuid);
+  console.log('2', user.tower_coordinates);
 
   if (!towerData) {
     socket.emit('towerInitial', { status: 'fail', message: '최초 타워 추가 검증 실패' });
@@ -13,7 +18,7 @@ export const towerInitialHandler = (userId, payload, socket) => {
   socket.emit('towerInitial', { status: 'success', message: '최초 타워 추가 완료', towerData });
 };
 
-export const towerPurchaseHandler = (userId, payload, socket) => {
+export const towerPurchaseHandler = (uuid, payload, socket) => {
   const { towerData } = payload;
 
   if (false) {
@@ -24,7 +29,7 @@ export const towerPurchaseHandler = (userId, payload, socket) => {
   socket.emit('towerPurchase', { status: 'success', message: '타워 구매 완료' });
 };
 
-export const towerRefundHandler = (userId, payload, socket) => {
+export const towerRefundHandler = (uuid, payload, socket) => {
   const { towerData } = payload;
 
   if (false) {
@@ -35,7 +40,7 @@ export const towerRefundHandler = (userId, payload, socket) => {
   socket.emit('towerRefund', { status: 'success', message: '타워 환불 성공' });
 };
 
-export const towerUpgradeHandler = (userId, payload, socket) => {
+export const towerUpgradeHandler = (uuid, payload, socket) => {
   const { towerData } = payload;
 
   if (false) {

--- a/src/utils/redis.utils.js
+++ b/src/utils/redis.utils.js
@@ -172,6 +172,53 @@ export const gameRedis = {
       console.error('Error patching game data: ', err);
     }
   },
+  // 임시
+  getGameDataTower: async function (uuid) {
+    try {
+      const key = `${GAME_DATA_PREFIX}${uuid}`;
+      const data = await redisClient.hVals(key);
+      if (data && data.length > 0) {
+        return {
+          [GAME_FIELD_TOWER]: JSON.parse(data[3]),
+        };
+      }
+    } catch (err) {
+      console.error('Error getting game data: ', err);
+      return null;
+    }
+  },
+  // 임시
+  patchGameDataTower: async function (uuid, towerData) {
+    try {
+      const tower = await this.getGameDataTower(uuid);
+      const baseData = tower[GAME_FIELD_TOWER];
+
+      console.log('baseData : ', baseData);
+
+      if (baseData !== '[]') {
+        console.log('베이스 없음');
+        const key = `${GAME_DATA_PREFIX}${uuid}`;
+        const exists = await redisClient.hExists(key, `${GAME_FIELD_TOWER}`);
+        if (exists) {
+          console.log('존재함');
+          await redisClient.hSet(key, `${GAME_FIELD_TOWER}`, JSON.stringify(towerData));
+        }
+      } else {
+        console.log('베이스 있음');
+        /* const key = `${GAME_DATA_PREFIX}${uuid}`;
+        const exists = await redisClient.hExists(key, `${GAME_FIELD_TOWER}`);
+        if (exists) {
+          const newData = JSON.parse(baseData[GAME_FIELD_TOWER]);
+          console.log('newData', newData);
+          newData.push(towerData);
+          console.log('pushed newData', newData);
+          await redisClient.hSet(key, `${GAME_FIELD_TOWER}`, JSON.stringify(newData));
+        } */
+      }
+    } catch (err) {
+      console.error('Error patching game data: ', err);
+    }
+  },
   patchGameDataGold: async function (uuid, newGold) {
     try {
       const key = `${GAME_DATA_PREFIX}${uuid}`;


### PR DESCRIPTION
### Update 최초 타워 추가 이벤트 Redis 연동

- 게임 시작 이벤트로 받아온 게임 데이터를 기반으로 최초 타워 추가 이벤트 송수신

### 참고사항

- 클라이언트에서 송신한 타워 좌표를 Redis에 저장하는 함수 임시 정의
- 실제 Redis에는 마지막 3번째 좌표만 저장되는 문제 발생

### Redis 데이터 이미지

![image](https://github.com/eliotjang/tower-defense-game-project/assets/37320831/da0a5e92-1419-4e95-9850-ebce87c38159)
