### PR TITLE
Update 타워 환불 기능

### DIFF
--- a/public/src/game.js
+++ b/public/src/game.js
@@ -160,6 +160,11 @@ function placeNewTower(x, y) {
   tower.draw(ctx, towerImages[tower.getLevel()]);
 }
 
+function refundTower(x, y) {
+  const index = towers.findIndex((e) => e.x === x && e.y === y);
+  towers.splice(index, 1);
+}
+
 function placeBase() {
   const lastPoint = monsterPath[monsterPath.length - 1];
   base = new Base(lastPoint.x, lastPoint.y, baseHp);
@@ -352,8 +357,9 @@ Promise.all([
 
   serverSocket.on('towerRefund', (data) => {
     if (data.status === 'success') {
+      userGold = data.userGold;
     } else {
-      alert('실패 메시지 입력');
+      alert('타워 환불 검증에 실패했습니다.');
     }
     console.log(data);
   });
@@ -397,8 +403,34 @@ buyTowerButton.style.cursor = 'pointer';
 
 buyTowerButton.addEventListener('click', () => {
   const { x, y } = getRandomPositionNearPath(200);
+  //const isExist = towers.findIndex()
   sendEvent(31, { towerData: { x, y }, towerIndex });
   towerIndex++;
 });
 
 document.body.appendChild(buyTowerButton);
+
+const refundTowerButton = document.createElement('button');
+refundTowerButton.textContent = '타워 판매(랜덤)';
+refundTowerButton.style.position = 'absolute';
+refundTowerButton.style.top = '10px';
+refundTowerButton.style.right = '130px';
+refundTowerButton.style.padding = '10px 20px';
+refundTowerButton.style.fontSize = '16px';
+refundTowerButton.style.cursor = 'pointer';
+
+refundTowerButton.addEventListener('click', () => {
+  if (towers.length === 0) {
+    alert('환불할 타워가 없습니다');
+    return;
+  }
+
+  const refundIndex = Math.floor(Math.random() * towers.length);
+  const targetTower = towers[refundIndex];
+
+  refundTower(targetTower.x, targetTower.y);
+  sendEvent(32, { towerData: { x: targetTower.x, y: targetTower.y } });
+  towerIndex++;
+});
+
+document.body.appendChild(refundTowerButton);

--- a/src/handlers/game.handler.js
+++ b/src/handlers/game.handler.js
@@ -16,6 +16,8 @@ export const gameStart = async (uuid, payload, socket) => {
 
   startTime = timeStamp;
 
+  await gameRedis.deleteGameDataTowerlist(uuid);
+
   await gameRedis.removeGameData(uuid);
   await gameRedis.createGameData(uuid, userGold, stageId, score, numOfInitialTowers, baseHp);
   const data = await gameRedis.getGameData(uuid);

--- a/src/utils/redis.utils.js
+++ b/src/utils/redis.utils.js
@@ -185,6 +185,34 @@ export const gameRedis = {
       console.error('Error patching game data (tower test): ', err);
     }
   },
+  deleteGameDataTower: async function (uuid, towerData) {
+    try {
+      const pattern = `${TOWERS_PREFIX}${uuid}*`;
+      const keys = await redisClient.keys(pattern);
+
+      for (let i = 0; i < keys.length; i++) {
+        const value = JSON.parse(await redisClient.get(keys[i]));
+
+        if (towerData.x === value.x && towerData.y === value.y) {
+          await redisClient.del(keys[i]);
+        }
+      }
+    } catch (err) {
+      console.error('Error delete game data (tower): ', err);
+    }
+  },
+  deleteGameDataTowerlist: async function (uuid) {
+    try {
+      const pattern = `${TOWERS_PREFIX}${uuid}*`;
+      const keys = await redisClient.keys(pattern);
+
+      for (let i = 0; i < keys.length; i++) {
+        await redisClient.del(keys[i]);
+      }
+    } catch (err) {
+      console.error('Error delete game data (tower list): ', err);
+    }
+  },
   getGameDataTowerList: async function (uuid) {
     try {
       const pattern = `${TOWERS_PREFIX}${uuid}*`;
@@ -197,7 +225,26 @@ export const gameRedis = {
       }
       return values;
     } catch (err) {
-      console.error('Error patching game data (tower test): ', err);
+      console.error('Error get game data (tower list): ', err);
+    }
+  },
+  getGameDataTower: async function (uuid, towerData) {
+    try {
+      const pattern = `${TOWERS_PREFIX}${uuid}*`;
+      const keys = await redisClient.keys(pattern);
+
+      const values = {};
+      for (let i = 0; i < keys.length; i++) {
+        const value = JSON.parse(await redisClient.get(keys[i]));
+
+        if (towerData.x === value.x && towerData.y === value.y) {
+          const key = keys[i].replace(`${TOWERS_PREFIX}${uuid}`, '');
+          values[key] = JSON.parse(await redisClient.get(keys[i]));
+        }
+      }
+      return values;
+    } catch (err) {
+      console.error('Error get game data (tower): ', err);
     }
   },
   /* ------------ */


### PR DESCRIPTION
### Update 타워 환불 기능

- Redis 함수 추가
  - `deleteGameDataTower`
  - `deleteGameDataTowerlist`
  - `getGameDataTower`
- 환불 시 500골드 추가
- 환불할 타워가 없을 경우 클라이언트에서 오류 처리
- 클라이언트에서 보낸 `towerData`가 Redis 데이터 내에 없을 경우 환불 검증 실패 처리

### 타워 환불 서버 콘솔창 이미지

![환불 콘솔 서버](https://github.com/eliotjang/tower-defense-game-project/assets/37320831/475d1fe3-ff55-4542-adca-ee4be99fa3d8)


### 환불할 타워가 없을 경우 alert 창 이미지

![환불 alert](https://github.com/eliotjang/tower-defense-game-project/assets/37320831/455c6cc0-d81f-4916-a06e-7b4d1813e598)


### 환불 검증 실패 alert 창 이미지

![환블 검증 실패 alert](https://github.com/eliotjang/tower-defense-game-project/assets/37320831/2cfd34b8-6b0f-48a8-8a59-75fbefb184b8)

